### PR TITLE
Initialize thread local value on each thread

### DIFF
--- a/btalib/indicator.py
+++ b/btalib/indicator.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-metadata.callstack = []  # keep indicators which are currently being executed
+metadata.register('callstack', list) # keep indicators which are currently being executed
 
 
 _NAMES_IND = {}

--- a/btalib/meta/lines.py
+++ b/btalib/meta/lines.py
@@ -607,8 +607,8 @@ class Line(metaclass=MetaLine):
 # instances, to avoid having them declared as attributes. Or else __setattr__
 # would set them as Line objects (or logic would be needed in __setattr__ to
 # avoid assigning an object not the real value
-metadata.minperiods = {}
-metadata.minperiod = {}
+metadata.register('minperiods', dict)
+metadata.register('minperiod', dict)
 
 
 class Lines:

--- a/btalib/meta/metadata.py
+++ b/btalib/meta/metadata.py
@@ -8,4 +8,21 @@ import threading
 
 __all__ = ['metadata']
 
-metadata = threading.local()
+
+class Metadata(object):
+
+    def __init__(self):
+        self._metadata = threading.local()
+
+    @classmethod
+    def register(cls, name, default=None):
+
+        def get_or_default(self):
+            if not hasattr(self._metadata, name):
+                setattr(self._metadata, name, default())
+            return getattr(self._metadata, name)
+
+        setattr(cls, name, property(get_or_default))
+
+
+metadata = Metadata()


### PR DESCRIPTION
Attributes on the thread local `metadata` variable were being initialized at import time by the calling thread.  All access from other threads were result in errors like `AttributeError: '_thread._local' object has no attribute 'minperiods''`.

This change make the initialization lazy via a property and binds to the calling thread.