### PR TITLE
Fixing an issue with the crossover indicator in python 3.7

### DIFF
--- a/btalib/indicators/crossover.py
+++ b/btalib/indicators/crossover.py
@@ -104,4 +104,4 @@ class crossover(_crossbase):
     _updown = 0
 
     def __init__(self):
-        self.o.crossover = self._cup - self._cdown
+        self.o.crossover = self._cup.astype(float) - self._cdown.astype(float)


### PR DESCRIPTION
The current version of the crossing indicator failed in Python 3.7.6 with numpy 1.18.1 and 0.25.3. The error is due to computing the difference of two boolean arrays in the modified line.

```
data["mcross"] = btalib.crossover(data["macd"], data["macd_signal"]).crossover
  File "/home/demattia/miniconda3/envs/yuco/lib/python3.7/site-packages/btalib/indicator.py", line 152, in __call__
    b_init(self, *args, **kwargs)
  File "/home/demattia/miniconda3/envs/yuco/lib/python3.7/site-packages/btalib/indicators/crossover.py", line 108, in __init__
    self.o.crossover = self._cup - self._cdown
  File "/home/demattia/miniconda3/envs/yuco/lib/python3.7/site-packages/btalib/meta/lines.py", line 129, in real_binary_op
    result[minidx:] = r = binop(other, *args, **kwargs)  # exec / store
  File "/home/demattia/miniconda3/envs/yuco/lib/python3.7/site-packages/pandas/core/ops/__init__.py", line 1048, in wrapper
    result = na_op(lvalues, rvalues)
  File "/home/demattia/miniconda3/envs/yuco/lib/python3.7/site-packages/pandas/core/ops/__init__.py", line 970, in na_op
    result = masked_arith_op(x, y, op)
  File "/home/demattia/miniconda3/envs/yuco/lib/python3.7/site-packages/pandas/core/ops/__init__.py", line 447, in masked_arith_op
    result[mask] = op(xrav[mask], com.values_from_object(yrav[mask]))
TypeError: numpy boolean subtract, the `-` operator, is not supported, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
```

The fix simply converts the arrays to floating point so as to obtain the intended behavior of the crossing returning -1, 0 or +1.